### PR TITLE
Course Status Tracker - Fix for Language and Notice: Trying to get prope...

### DIFF
--- a/block_course_status_tracker.php
+++ b/block_course_status_tracker.php
@@ -19,18 +19,11 @@
  * It also shows the number of courses which are in progress and whose completion criteria is undefined but the manger.
  * @package blocks
  * @author: Azmat Ullah, Talha Noor
- * @date: 2013
  */
 
 require_once('lib.php');
 /**
  * This class shows the content in block through calling lib.php function.
- *
- *
- *
- * @package    block
- * @copyright  Copyrights © 2012 - 2013 | 3i Logic Innovations Co.(Pvt) Ltd. All Rights Reserved.
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 class block_course_status_tracker extends block_base {

--- a/block_course_status_tracker.php
+++ b/block_course_status_tracker.php
@@ -18,7 +18,7 @@
  * The plugin shows the number and list of enrolled courses and completed courses.
  * It also shows the number of courses which are in progress and whose completion criteria is undefined but the manger.
  * @package blocks
- * @author: Azmat Ullah, Talha Noor
+ * @author: Azmat Ullah, Talha Noor, Michael Milette (www.instruxmedia.com)
  */
 
 require_once('lib.php');
@@ -35,7 +35,10 @@ class block_course_status_tracker extends block_base {
      *
      * @return boolean
      **/
-    public function applicable_formats() {
+//    public function applicable_formats() {
+//        return array('site' => true, 'course' => true, 'my' => true);
+//    }
+     public function applicable_formats() {
         return array('all' => true);
     }
     /**
@@ -52,32 +55,31 @@ class block_course_status_tracker extends block_base {
         }
         $this->content = new stdClass;
         if ($CFG->enablecompletion) {
-            // $enrolled_courses=user_enrolled_courses($USER->id);
             // Enrolled courses.
-			 $count_course=0;
-    		 $courses = enrol_get_users_courses($USER->id, false, 'id, shortname, showgrades');
-    		 if ($courses) {
+            // $enrolled_courses=user_enrolled_courses($USER->id);
+             $count_course=0;
+             $courses = enrol_get_users_courses($USER->id, false, 'id, shortname, showgrades');
+             if ($courses) {
                  foreach ($courses as $course) {
                      $count_course+=1;
                  }
         }
-    		$enrolled_courses = $count_course;
-			// End enrolled courses.
-            // $count_complete_courses=count_complete_course($USER->id);
+            $enrolled_courses = $count_course;
+            // End enrolled courses.
             // Completed courses.
             // $count_complete_courses=count_complete_course($USER->id);
-			$total_courses=$DB->get_record_sql('SELECT count(course) as total_course FROM {course_completion_crit_compl} 						                                               WHERE userid = ?', array($USER->id));
-                                        
+            $total_courses=$DB->get_record_sql('SELECT count(course) as total_course FROM {course_completion_crit_compl} WHERE userid = ?', array($USER->id));
+
             $total_courses=$total_courses->total_course;
             $count_complete_courses=$total_courses;
-			// End completed courses.
-            // $course_criteria_not_set=count_course_criteria($USER->id);
+            // End completed courses.
+
             // Course criteria not set.
             // $course_criteria_not_set=count_course_criteria($USER->id);
-			 $count=0;
+             $count=0;
              $courses = enrol_get_users_courses($USER->id, false, 'id, shortname, showgrades');
              if ($courses) {
-        	     $course_criteria_ns = array();
+                 $course_criteria_ns = array();
                  foreach ($courses as $course) {
                      $exist = $DB->record_exists('course_completion_criteria', array('course' => $course->id));
                      if(!$exist) {
@@ -87,7 +89,8 @@ class block_course_status_tracker extends block_base {
              }
             }
             $course_criteria_not_set= $count;
-			// End course criteria.
+            // End course criteria.
+            // Course in progress
             $count_inprogress_courses=($enrolled_courses)-($count_complete_courses+$course_criteria_not_set);
             if ($enrolled_courses > 0) {
                 $link_enrolled_courses = "<u><a href='".$CFG->wwwroot."/blocks/course_status_tracker/view.php?viewpage=2'>".
@@ -105,7 +108,7 @@ class block_course_status_tracker extends block_base {
                                             $course_criteria_not_set."</a>";
             $link_count_inprogress_courses = "<a href='".$CFG->wwwroot."/blocks/course_status_tracker/view.php?viewpage=1'>".
                                              $count_inprogress_courses."</a>";
-             $this->content->text .= get_string('enrolled_courses', 'block_course_status_tracker')." :	<b>".$link_enrolled_courses."</b><br>";
+            $this->content->text .= get_string('enrolled_courses', 'block_course_status_tracker')." : <b>".$link_enrolled_courses."</b><br>";
             $this->content->text .= get_string('completed_courses', 'block_course_status_tracker')." : <b>".$link_count_complete_courses."</b><br>";
             $this->content->text .= get_string('inprogress_courses', 'block_course_status_tracker')." : <b>".$count_inprogress_courses."</b><br>";
             $this->content->text .= get_string('undefined_coursecriteria', 'block_course_status_tracker')." : <b>".$course_criteria_not_set."</b><br>";
@@ -114,4 +117,4 @@ class block_course_status_tracker extends block_base {
         }
         return $this->content;
     }
-}   
+}

--- a/block_course_status_tracker.php
+++ b/block_course_status_tracker.php
@@ -72,12 +72,12 @@ class block_course_status_tracker extends block_base {
                                             $course_criteria_not_set."</a>";
             $link_count_inprogress_courses = "<a href='".$CFG->wwwroot."/blocks/course_status_tracker/view.php?viewpage=1'>".
                                              $count_inprogress_courses."</a>";
-            $this->content->text .= "Enrolled Courses :	<b>".$link_enrolled_courses."</b><br>";
-            $this->content->text .= "Completed Courses : <b>".$link_count_complete_courses."</b><br>";
-            $this->content->text .= "Course In Progress : <b>".$count_inprogress_courses."</b><br>";
-            $this->content->text .= "Undefined Course Criteria : <b>".$course_criteria_not_set."</b><br>";
+             $this->content->text .= get_string('enrolled_courses', 'block_course_status_tracker')." :	<b>".$link_enrolled_courses."</b><br>";
+            $this->content->text .= get_string('completed_courses', 'block_course_status_tracker')." : <b>".$link_count_complete_courses."</b><br>";
+            $this->content->text .= get_string('inprogress_courses', 'block_course_status_tracker')." : <b>".$count_inprogress_courses."</b><br>";
+            $this->content->text .= get_string('undefined_coursecriteria', 'block_course_status_tracker')." : <b>".$course_criteria_not_set."</b><br>";
         } else {
-              $this->content->text .= "Course Completion has not enable yet";
+              $this->content->text .= get_string('coursecompletion_setting', 'block_course_status_tracker');
         }
         return $this->content;
     }

--- a/block_course_status_tracker.php
+++ b/block_course_status_tracker.php
@@ -1,0 +1,91 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/* Course Status Tracker Block
+ * The plugin shows the number and list of enrolled courses and completed courses.
+ * It also shows the number of courses which are in progress and whose completion criteria is undefined but the manger.
+ * @package blocks
+ * @author: Azmat Ullah, Talha Noor
+ * @date: 2013
+ */
+
+require_once('lib.php');
+/**
+ * This class shows the content in block through calling lib.php function.
+ *
+ *
+ *
+ * @package    block
+ * @copyright  Copyrights © 2012 - 2013 | 3i Logic Innovations Co.(Pvt) Ltd. All Rights Reserved.
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+class block_course_status_tracker extends block_base {
+    public function init() {
+        $this->title = get_string('course_status_tracker', 'block_course_status_tracker');
+    }
+    /**
+     * Where to add the block
+     *
+     * @return boolean
+     **/
+    public function applicable_formats() {
+        return array('site' => true, 'course' => false);
+    }
+    /**
+     * Gets the contents of the block (course view)
+     *
+     * @return object An object with the contents
+     **/
+     public function isguestuser($user = null)
+     {return false;}
+    public function get_content() {
+        global $CFG, $OUTPUT, $USER;
+        if ($this->content !== null) {
+            return $this->content;
+        }
+        $this->content = new stdClass;
+        if ($CFG->enablecompletion) {
+            $enrolled_courses=user_enrolled_courses($USER->id);
+            $count_complete_courses=count_complete_course($USER->id);
+            $course_criteria_not_set=count_course_criteria($USER->id);
+            $count_inprogress_courses=($enrolled_courses)-($count_complete_courses+$course_criteria_not_set);
+            if ($enrolled_courses > 0) {
+                $link_enrolled_courses = "<u><a href='".$CFG->wwwroot."/blocks/course_status_tracker/view.php?viewpage=2'>".
+                                         $enrolled_courses."</a></u>";
+            } else {
+                $link_enrolled_courses = $enrolled_courses;
+            }
+            if ($count_complete_courses > 0) {
+                $link_count_complete_courses = "<u><a href='".$CFG->wwwroot."/blocks/course_status_tracker/view.php?viewpage=1'>".
+                                                $count_complete_courses."</a></u>";
+            } else {
+                $link_count_complete_courses = $count_complete_courses;
+            }
+            $link_course_criteria_not_set = "<a href='".$CFG->wwwroot."/blocks/course_status_tracker/view.php?viewpage=1'>".
+                                            $course_criteria_not_set."</a>";
+            $link_count_inprogress_courses = "<a href='".$CFG->wwwroot."/blocks/course_status_tracker/view.php?viewpage=1'>".
+                                             $count_inprogress_courses."</a>";
+            $this->content->text .= "Enrolled Courses :	<b>".$link_enrolled_courses."</b><br>";
+            $this->content->text .= "Completed Courses : <b>".$link_count_complete_courses."</b><br>";
+            $this->content->text .= "Course In Progress : <b>".$count_inprogress_courses."</b><br>";
+            $this->content->text .= "Undefined Course Criteria : <b>".$course_criteria_not_set."</b><br>";
+        } else {
+              $this->content->text .= "Course Completion has not enable yet";
+        }
+        return $this->content;
+    }
+}   

--- a/course_form.php
+++ b/course_form.php
@@ -1,0 +1,99 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/* Course Status Tracker Block
+ * The plugin shows the number and list of enrolled courses and completed courses.
+ * It also shows the number of courses which are in progress and whose completion criteria is undefined but the manger.
+ * @package blocks
+ * @author: Azmat Ullah, Talha Noor
+ 
+ * @date: 2013
+ */
+require_once("{$CFG->libdir}/formslib.php");
+require_once("lib.php");
+/**
+ * This class contains function display_report which return user course name, course grade & completion date.
+ *
+ *
+ *
+ * @package    blocks
+ * @copyright  Copyrights © 2012 - 2013 | 3i Logic Innovations Co.(Pvt) Ltd. All Rights Reserved.
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class course_status_form extends moodleform {
+    public function definition() {
+        return false;
+    }
+    public function display_report() {
+        global $DB, $OUTPUT, $CFG, $USER;
+        $userid = $USER->id;
+        // Page parameters.
+        $page    = optional_param('page', 0, PARAM_INT);
+        $perpage = optional_param('perpage', 30, PARAM_INT);    // How many record per page.
+        $sort    = optional_param('sort', 'firstname', PARAM_ALPHA);
+        $dir     = optional_param('dir', 'DESC', PARAM_ALPHA);
+        $sql = "SELECT course, gradefinal, DATE_FORMAT(DATE( FROM_UNIXTIME(timecompleted)),'%d-%b-%y')as dates FROM {course_completion_crit_compl} where userid = ".$userid;
+        $changescount = $DB->count_records_sql($sql, array($userid));
+        $columns = array('s_no' => get_string('s_no', 'block_course_status'),
+                         'course_name' => get_string('course_name', 'block_course_status'),
+                         'course_comp_date' => get_string('course_comp_date', 'block_course_status'),
+                         'grade' => get_string('grade', 'block_course_status'),
+                        );
+        $hcolumns = array();
+        if (!isset($columns[$sort])) {
+            $sort = 's_no';
+        }
+        foreach ($columns as $column => $strcolumn) {
+            if ($sort != $column) {
+                $columnicon = '';
+                if ($column == 's_no') {
+                    $columndir = 'DESC';
+                } else {
+                    $columndir = 'ASC';
+                }
+            } else {
+                $columndir = $dir == 'ASC' ? 'DESC':'ASC';
+                if ($column == 's_no') {
+                    $columnicon = $dir == 'ASC' ? 'up':'down';
+                } else {
+                    $columnicon = $dir == 'ASC' ? 'down':'up';
+                }
+                $columnicon = " <img src=\"" . $OUTPUT->pix_url('t/' . $columnicon) . "\" alt=\"\" />";
+            }
+            $hcolumns[$column] = "<a href=\"view.php?viewpage=1&sort=$column&amp;dir=$columndir&amp;page=$page&amp;perpage=$perpage\">".$strcolumn."</a>$columnicon";
+        }
+        $baseurl = new moodle_url('view.php', array('sort' => $sort, 'dir' => $dir, 'perpage' => $perpage));
+        echo $OUTPUT->paging_bar($changescount, $page, $perpage, $baseurl);
+        $table = new html_table();
+        $table->head  = array('S. No.', 'Course Name', 'Course Completion Date', 'Grade');
+        $table->size  = array('10%', '30%', '40%', '20%');
+        $table->align  = array('center', 'left', 'center', 'center');
+        $table->width = '80%';
+        $table->data  = array();
+        $orderby = "$sort $dir";
+        $rs = $DB->get_recordset_sql($sql, array(),  $page*$perpage, $perpage);
+        $i=0;
+        foreach ($rs as $log) {
+            $row = array();
+            $row[] = ++$i;
+            $row[] = course_name($log->course);
+            $row[] = $log->dates;
+            $row[] = round($log->gradefinal).'%';
+            $table->data[] = $row;
+        }
+        return $table;
+    }
+}

--- a/course_form.php
+++ b/course_form.php
@@ -71,7 +71,7 @@ class course_status_form extends moodleform {
         $baseurl = new moodle_url('view.php', array('sort' => $sort, 'dir' => $dir, 'perpage' => $perpage));
         echo $OUTPUT->paging_bar($changescount, $page, $perpage, $baseurl);
         $table = new html_table();
-        $table->head  = array('Serial No.', 'Course Name', 'Course Completion Date', 'Grade');
+        $table->head  = array(get_string('s_no', 'block_course_status_tracker'), get_string('course_name', 'block_course_status_tracker'), get_string('course_comp_date', 'block_course_status_tracker'), get_string('grade', 'block_course_status_tracker'));
         $table->size  = array('10%', '30%', '40%', '20%');
         $table->align  = array('center', 'left', 'center', 'center');
         $table->width = '80%';

--- a/course_form.php
+++ b/course_form.php
@@ -71,7 +71,7 @@ class course_status_form extends moodleform {
         $baseurl = new moodle_url('view.php', array('sort' => $sort, 'dir' => $dir, 'perpage' => $perpage));
         echo $OUTPUT->paging_bar($changescount, $page, $perpage, $baseurl);
         $table = new html_table();
-        $table->head  = array('S. No.', 'Course Name', 'Course Completion Date', 'Grade');
+        $table->head  = array('Serial No.', 'Course Name', 'Course Completion Date', 'Grade');
         $table->size  = array('10%', '30%', '40%', '20%');
         $table->align  = array('center', 'left', 'center', 'center');
         $table->width = '80%';

--- a/course_form.php
+++ b/course_form.php
@@ -22,14 +22,9 @@
  */
 require_once("{$CFG->libdir}/formslib.php");
 require_once("lib.php");
+
 /**
  * This class contains function display_report which return user course name, course grade & completion date.
- *
- *
- *
- * @package    blocks
- * @copyright  Copyrights � 2012 - 2013 | 3i Logic Innovations Co.(Pvt) Ltd. All Rights Reserved.
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class course_status_form extends moodleform {
     public function definition() {

--- a/course_form.php
+++ b/course_form.php
@@ -19,8 +19,6 @@
  * It also shows the number of courses which are in progress and whose completion criteria is undefined but the manger.
  * @package blocks
  * @author: Azmat Ullah, Talha Noor
- 
- * @date: 2013
  */
 require_once("{$CFG->libdir}/formslib.php");
 require_once("lib.php");
@@ -30,7 +28,7 @@ require_once("lib.php");
  *
  *
  * @package    blocks
- * @copyright  Copyrights © 2012 - 2013 | 3i Logic Innovations Co.(Pvt) Ltd. All Rights Reserved.
+ * @copyright  Copyrights ï¿½ 2012 - 2013 | 3i Logic Innovations Co.(Pvt) Ltd. All Rights Reserved.
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class course_status_form extends moodleform {

--- a/course_form.php
+++ b/course_form.php
@@ -18,7 +18,7 @@
  * The plugin shows the number and list of enrolled courses and completed courses.
  * It also shows the number of courses which are in progress and whose completion criteria is undefined but the manger.
  * @package blocks
- * @author: Azmat Ullah, Talha Noor
+ * @author: Azmat Ullah, Talha Noor, Michael Milette (www.instruxmedia.com)
  */
 require_once("{$CFG->libdir}/formslib.php");
 require_once("lib.php");
@@ -38,7 +38,7 @@ class course_status_form extends moodleform {
         $perpage = optional_param('perpage', 30, PARAM_INT);    // How many record per page.
         $sort    = optional_param('sort', 'firstname', PARAM_ALPHA);
         $dir     = optional_param('dir', 'DESC', PARAM_ALPHA);
-        $sql = "SELECT course, gradefinal, DATE_FORMAT(DATE( FROM_UNIXTIME(timecompleted)),'%d-%b-%y')as dates FROM {course_completion_crit_compl} where userid = ".$userid;
+        $sql = "SELECT course, gradefinal, timecompleted as dates FROM {course_completion_crit_compl} where userid = ".$userid;
         $changescount = $DB->count_records_sql($sql, array($userid));
         $columns = array('s_no' => get_string('s_no', 'block_course_status'),
                          'course_name' => get_string('course_name', 'block_course_status'),
@@ -83,7 +83,7 @@ class course_status_form extends moodleform {
             $row = array();
             $row[] = ++$i;
             $row[] = course_name($log->course);
-            $row[] = $log->dates;
+            $row[] = userdate($log->dates, get_string('strftimedate', 'core_langconfig'));
             $row[] = round($log->gradefinal).'%';
             $table->data[] = $row;
         }

--- a/db/access.php
+++ b/db/access.php
@@ -1,0 +1,41 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/* Course Status Tracker Block
+ * The plugin shows the number and list of enrolled courses and completed courses.
+ * It also shows the number of courses which are in progress and whose completion criteria is undefined but the manger.
+ * @package blocks
+ * @author: Azmat Ullah, Talha Noor
+ * @date: 2013
+ */
+
+defined('MOODLE_INTERNAL') || die();
+$capabilities = array(
+
+    'block/course_status_tracker' => array(
+
+        'captype' => 'read',
+        'contextlevel' => CONTEXT_COURSE,
+        'legacy' => array(
+            'guest' => CAP_PREVENT,
+            'student' => CAP_ALLOW,
+            'teacher' => CAP_ALLOW,
+            'editingteacher' => CAP_ALLOW,
+            'coursecreator' => CAP_ALLOW,
+            'manager' => CAP_ALLOW
+        )
+    )
+   );

--- a/db/access.php
+++ b/db/access.php
@@ -19,23 +19,40 @@
  * It also shows the number of courses which are in progress and whose completion criteria is undefined but the manger.
  * @package blocks
  * @author: Azmat Ullah, Talha Noor
- * @date: 2013
  */
 
 defined('MOODLE_INTERNAL') || die();
 $capabilities = array(
-
-    'block/course_status_tracker' => array(
-
+    'block/course_status:myaddinstance' => array(
+        'captype' => 'write',
+        'contextlevel' => CONTEXT_COURSE,
+        'archetypes' => array(
+            'user' => CAP_ALLOW
+        ),
+ 
+        'clonepermissionsfrom' => 'moodle/my:manageblocks'
+    ),
+ 
+    'block/course_status:addinstance' => array(
+        'riskbitmask' => RISK_SPAM | RISK_XSS,
+ 
+        'captype' => 'write',
+        'contextlevel' => CONTEXT_BLOCK,
+        'archetypes' => array(
+            'editingteacher' => CAP_ALLOW,
+            'manager' => CAP_ALLOW,
+            ),
+ 
+        'clonepermissionsfrom' => 'moodle/site:manageblocks'
+    ),
+        'block/course_status:view' => array(
         'captype' => 'read',
         'contextlevel' => CONTEXT_COURSE,
-        'legacy' => array(
-            'guest' => CAP_PREVENT,
-            'student' => CAP_ALLOW,
-            'teacher' => CAP_ALLOW,
-            'editingteacher' => CAP_ALLOW,
-            'coursecreator' => CAP_ALLOW,
-            'manager' => CAP_ALLOW
-        )
-    )
-   );
+        'archetypes' => array(
+            
+            'guest'        => CAP_PREVENT
+            
+            ),
+ 
+        ),
+);

--- a/lang/en/block_course_status_tracker.php
+++ b/lang/en/block_course_status_tracker.php
@@ -18,12 +18,12 @@
  * The plugin shows the number and list of enrolled courses and completed courses.
  * It also shows the number of courses which are in progress and whose completion criteria is undefined but the manger.
  * @package blocks
- * @author: Azmat Ullah, Talha Noor
+ * @author: Azmat Ullah, Talha Noor, Michael Milette (www.instruxmedia.com)
  */
 $string['pluginname']='Course Status Tracker';
 $string['course_status']='Course Status Tracker';
 $string['course_status_tracker']='Course Status Tracker';
-$string['s_no']='S. No.';
+$string['s_no']='<abbr title="Number">No.</abbr>';
 $string['course_name']='Course Name';
 $string['course_comp_date']='Course Completion Date';
 $string['grade']='Grade';
@@ -39,7 +39,6 @@ $string['department']='Department';
 $string['joining_date']='Joining Date';
 $string['course']='Course';
 $string['report_coursecompletion']='Course Completion Report';
-$string['report_courseenrollment']='Course Enrollment Report';
+$string['report_courseenrollment']='Course Enrolment Report';
 $string['module']='Module';
 $string['name']='Name';
-

--- a/lang/en/block_course_status_tracker.php
+++ b/lang/en/block_course_status_tracker.php
@@ -1,0 +1,30 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/* Course Status Tracker Block
+ * The plugin shows the number and list of enrolled courses and completed courses.
+ * It also shows the number of courses which are in progress and whose completion criteria is undefined but the manger.
+ * @package blocks
+ * @author: Azmat Ullah, Talha Noor
+ * @date: 2013
+ */
+$string['pluginname']='Course Status Tracker';
+$string['course_status']='Course Status Tracker';
+$string['course_status_tracker']='Course Status Tracker';
+$string['s_no']='S. No.';
+$string['course_name']='Course Name';
+$string['course_comp_date']='Course Completion Date';
+$string['grade']='Grade';

--- a/lang/en/block_course_status_tracker.php
+++ b/lang/en/block_course_status_tracker.php
@@ -29,3 +29,17 @@ $string['course_comp_date']='Course Completion Date';
 $string['grade']='Grade';
 $string['course_status_tracker:view']='Course Status View';
 $string['course_status_tracker:addinstance']='Add Instance';
+$string['enrolled_courses']='Enrolled Courses';
+$string['completed_courses']='Completed Courses';
+$string['inprogress_courses']='Course In Progress';
+$string['undefined_coursecriteria']='Undefined Course Criteria';
+$string['coursecompletion_setting']='Course Completion has not enable yet';
+$string['job_title']='Job Title';
+$string['department']='Department';
+$string['joining_date']='Joining Date';
+$string['course']='Course';
+$string['report_coursecompletion']='Course Completion Report';
+$string['report_courseenrollment']='Course Enrollment Report';
+$string['module']='Module';
+$string['name']='Name';
+

--- a/lang/en/block_course_status_tracker.php
+++ b/lang/en/block_course_status_tracker.php
@@ -27,5 +27,5 @@ $string['s_no']='S. No.';
 $string['course_name']='Course Name';
 $string['course_comp_date']='Course Completion Date';
 $string['grade']='Grade';
-$string['course_status:view']='Course Status View';
-$string['course_status:addinstance']='Add Instance';
+$string['course_status_tracker:view']='Course Status View';
+$string['course_status_tracker:addinstance']='Add Instance';

--- a/lang/en/block_course_status_tracker.php
+++ b/lang/en/block_course_status_tracker.php
@@ -19,7 +19,6 @@
  * It also shows the number of courses which are in progress and whose completion criteria is undefined but the manger.
  * @package blocks
  * @author: Azmat Ullah, Talha Noor
- * @date: 2013
  */
 $string['pluginname']='Course Status Tracker';
 $string['course_status']='Course Status Tracker';
@@ -28,3 +27,5 @@ $string['s_no']='S. No.';
 $string['course_name']='Course Name';
 $string['course_comp_date']='Course Completion Date';
 $string['grade']='Grade';
+$string['course_status:view']='Course Status View';
+$string['course_status:addinstance']='Add Instance';

--- a/lib.php
+++ b/lib.php
@@ -161,7 +161,7 @@ function user_enrolled_courses_report($userid) {
     $courses = enrol_get_users_courses($userid, false, 'id, shortname, showgrades');
     if ($courses) {
         $table = new html_table();
-        $table->head  = array('S. No.', 'Module', 'Course Name');
+        $table->head  = array('Serial No.', 'Module', 'Course Name');
         $table->size  = array('15%', '35%', '50%');
         $table->align = array('center', 'left', 'left');
         $table->width = '80%';

--- a/lib.php
+++ b/lib.php
@@ -98,7 +98,7 @@ function course_name($id) {
     $course=$DB->get_record_sql('SELECT fullname  FROM {course} WHERE id = ?',
                                  array($id));
     $course=$course->fullname;
-    $course=$course. ' Course';
+    $course=$course.' '.get_string('course', 'block_course_status_tracker');
     return $course;
 }
 /**
@@ -117,14 +117,14 @@ function user_details($id) {
     $result = $DB->get_record_sql('SELECT concat(firstname," ",lastname) as name,department,DATE_FORMAT(DATE(FROM_UNIXTIME(timecreated)),"%d-%b-%y")
                                   as date  FROM {user} WHERE id = ?', array($id));
     $table='<table width="80%"><tr><td width="20%" style="vertical-align:middle;" rowspan="5">'.$user->picture.'</td></tr>
-           <tr><td width="20%">Name</td><td>'.$result->name.'</td></tr>';
+           <tr><td width="20%">'.get_string('name', 'block_course_status_tracker').'</td><td>'.$result->name.'</td></tr>';
 
     $check_designatino_field=get_custome_field($id, "Designation"); // Custom Field name for designation is "Designation".
     if($check_designatino_field != 0 ) {
         $table .='<tr><td>Job Title</td><td>'.$check_designatino_field.'</td></tr>';
     }
-    $table .='<tr><td>Department</td><td>'.$result->department.'</td></tr>
-             <tr><td>Joining Date</td><td>'.$result->date.'</td></tr>
+   $table .='<tr><td>'.get_string('department', 'block_course_status_tracker').'</td><td>'.$result->department.'</td></tr>
+             <tr><td>'.get_string('joining_date', 'block_course_status_tracker').'</td><td>'.$result->date.'</td></tr>
              </table>';
     return $table;
 }
@@ -161,7 +161,7 @@ function user_enrolled_courses_report($userid) {
     $courses = enrol_get_users_courses($userid, false, 'id, shortname, showgrades');
     if ($courses) {
         $table = new html_table();
-        $table->head  = array('Serial No.', 'Module', 'Course Name');
+        $table->head  = array(get_string('s_no', 'block_course_status_tracker'), get_string('module', 'block_course_status_tracker'), get_string('course_name', 'block_course_status_tracker'));
         $table->size  = array('15%', '35%', '50%');
         $table->align = array('center', 'left', 'left');
         $table->width = '80%';

--- a/lib.php
+++ b/lib.php
@@ -19,7 +19,6 @@
  * It also shows the number of courses which are in progress and whose completion criteria is undefined but the manger.
  * @package blocks
  * @author: Azmat Ullah, Talha Noor
- * @date: 2013
  */
 
 /**

--- a/lib.php
+++ b/lib.php
@@ -1,0 +1,180 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/* Course Status Tracker Block
+ * The plugin shows the number and list of enrolled courses and completed courses.
+ * It also shows the number of courses which are in progress and whose completion criteria is undefined but the manger.
+ * @package blocks
+ * @author: Azmat Ullah, Talha Noor
+ * @date: 2013
+ */
+
+/**
+ * This function count the total completed courses of any user
+ *
+ * @param int   $userid Variable
+ * @return String $total_courses return total completed courses of any use.
+ */
+function count_complete_course($userid) {
+    global $DB;
+    $total_courses=$DB->get_record_sql('SELECT count(course) as total_course FROM {course_completion_crit_compl} WHERE userid = ?',
+                                        array($userid));
+    $total_courses=$total_courses->total_course;
+    return $total_courses;
+}
+/**
+ * This function retrun the total number of enrolled courses
+ *
+ * @see enrol_get_users_courses()
+ * @param int   $userid Moodle user id 
+ * @return String $count_course return total enrolled courses.
+ */
+function user_enrolled_courses($userid) {
+    global $CFG;
+    $count_course=0;
+    $courses = enrol_get_users_courses($userid, false, 'id, shortname, showgrades');
+    if ($courses) {
+        foreach ($courses as $course) {
+            $count_course+=1;
+        }
+    }
+    return $count_course;
+}
+/**
+ * This function tells how many enrolled courses criteria has not set yet of the user.
+ *
+ * @see enrol_get_users_courses()
+ * @param int   $userid Moodle user id
+ * @return String $count return number that tells total undefined course criteria of course.
+ */
+function count_course_criteria($userid) {
+    global $DB;
+    $count=0;
+    $courses = enrol_get_users_courses($userid, false, 'id, shortname, showgrades');
+    if ($courses) {
+        $course_criteria_ns = array();
+        foreach ($courses as $course) {
+            $exist = $DB->record_exists('course_completion_criteria', array('course' => $course->id));
+            if(!$exist) {
+                $count++;
+                $course_criteria_ns[] = $course->id;
+            }
+        }
+    }
+    return $count;
+}
+/**
+ * This function return the course category.
+ *
+ * @param int   $id Moodle course id
+ * @return String $module return category name of course.
+ */
+function module_name($id) {
+    global $DB;
+    $module=$DB->get_record_sql('SELECT name FROM {course_categories}  WHERE id = ?', array($id));
+    $module=$module->name;
+    return $module;
+}
+/**
+ * This function return course name on the base of course id.
+ *
+ * @param int   $course Moodle course id
+ * @return String $course Moodle course name.
+ */
+function course_name($id) {
+    global $DB;
+    $course=$DB->get_record_sql('SELECT fullname  FROM {course} WHERE id = ?',
+                                 array($id));
+    $course=$course->fullname;
+    $course=$course. ' Course';
+    return $course;
+}
+/**
+ * This function return user detail in the form of table.
+ *
+ * @see get_custome_field($id, "Designation") This function return custom field Designation value on the bass userid
+ * @param int   $id Moodle userid
+ * @return String $table Moodle course name.
+ */
+function user_details($id) {
+    global $OUTPUT, $DB;
+    $user = new stdClass();
+    $user->id = $id; // User Id.
+    $user->picture = $OUTPUT->user_picture($user, array('size'=>100));
+    // Fetch Data.
+    $result = $DB->get_record_sql('SELECT concat(firstname," ",lastname) as name,department,DATE_FORMAT(DATE(FROM_UNIXTIME(timecreated)),"%d-%b-%y")
+                                  as date  FROM {user} WHERE id = ?', array($id));
+    $table='<table width="80%"><tr><td width="20%" style="vertical-align:middle;" rowspan="5">'.$user->picture.'</td></tr>
+           <tr><td width="20%">Name</td><td>'.$result->name.'</td></tr>';
+
+    $check_designatino_field=get_custome_field($id, "Designation"); // Custom Field name for designation is "Designation".
+    if($check_designatino_field != 0 ) {
+        $table .='<tr><td>Job Title</td><td>'.$check_designatino_field.'</td></tr>';
+    }
+    $table .='<tr><td>Department</td><td>'.$result->department.'</td></tr>
+             <tr><td>Joining Date</td><td>'.$result->date.'</td></tr>
+             </table>';
+    return $table;
+}
+/**
+ * This function return the value of custom field on the base of parameter field name.
+ *
+ * @param int    $userid Moodle userid
+ * @param string $text custom field name
+ * @return string Return field value.
+ */
+function get_custome_field($userid, $text) {
+    global $DB;
+    $result = $DB->get_record_sql('SELECT table2.data as fieldvalue  FROM {user_info_field} as table1  join  {user_info_data} as table2
+                                   on table1.id=table2.fieldid where table2.userid=? AND table1.name=?',
+                                   array($userid, $text));
+    $fieldvalue=$result->fieldvalue;
+    if(empty($fieldvalue)) {
+        return "0";
+    } else {
+        return $result->fieldvalue;
+    }
+}
+/**
+ * This function return list of courses in which user enrolled.
+ *
+ * @see module_name()
+ * @enrol_get_users_courses
+ * @param int    $userid Moodle userid
+ * @return  Return table in which user can see the enrolled courses list.
+ */
+function user_enrolled_courses_report($userid) {
+    global $CFG;
+    $count_course=0;
+    $courses = enrol_get_users_courses($userid, false, 'id, shortname, showgrades');
+    if ($courses) {
+        $table = new html_table();
+        $table->head  = array('S. No.', 'Module', 'Course Name');
+        $table->size  = array('15%', '35%', '50%');
+        $table->align = array('center', 'left', 'left');
+        $table->width = '80%';
+        $table->data  = array();
+        $i=0;
+        foreach ($courses as $course) {
+            $row = array();
+            $row[] = ++$i;
+            $row[] = module_name($course->category);
+            $row[] = "<a href=".$CFG->wwwroot."/course/view.php?id=".$course->id.">".course_name($course->id)."</a>";
+            $table->data[] = $row;
+        }
+    }
+    return $table;
+}

--- a/lib.php
+++ b/lib.php
@@ -18,7 +18,7 @@
  * The plugin shows the number and list of enrolled courses and completed courses.
  * It also shows the number of courses which are in progress and whose completion criteria is undefined but the manger.
  * @package blocks
- * @author: Azmat Ullah, Talha Noor
+ * @author: Azmat Ullah, Talha Noor, Michael Milette (www.instruxmedia.com)
  */
 
 /**
@@ -38,7 +38,7 @@ function count_complete_course($userid) {
  * This function retrun the total number of enrolled courses
  *
  * @see enrol_get_users_courses()
- * @param int   $userid Moodle user id 
+ * @param int   $userid Moodle user id
  * @return String $count_course return total enrolled courses.
  */
 function user_enrolled_courses($userid) {
@@ -84,7 +84,7 @@ function count_course_criteria($userid) {
 function module_name($id) {
     global $DB;
     $module=$DB->get_record_sql('SELECT name FROM {course_categories}  WHERE id = ?', array($id));
-    $module=$module->name;
+    $module=format_string($module->name);
     return $module;
 }
 /**
@@ -97,7 +97,7 @@ function course_name($id) {
     global $DB;
     $course=$DB->get_record_sql('SELECT fullname  FROM {course} WHERE id = ?',
                                  array($id));
-    $course=$course->fullname;
+    $course=format_string($course->fullname);
     $course=$course.' '.get_string('course', 'block_course_status_tracker');
     return $course;
 }
@@ -114,17 +114,17 @@ function user_details($id) {
     $user->id = $id; // User Id.
     $user->picture = $OUTPUT->user_picture($user, array('size'=>100));
     // Fetch Data.
-    $result = $DB->get_record_sql('SELECT concat(firstname," ",lastname) as name,department,DATE_FORMAT(DATE(FROM_UNIXTIME(timecreated)),"%d-%b-%y")
+    $result = $DB->get_record_sql('SELECT concat(firstname," ",lastname) as name,department,timecreated
                                   as date  FROM {user} WHERE id = ?', array($id));
     $table='<table width="80%"><tr><td width="20%" style="vertical-align:middle;" rowspan="5">'.$user->picture.'</td></tr>
            <tr><td width="20%">'.get_string('name', 'block_course_status_tracker').'</td><td>'.$result->name.'</td></tr>';
 
     $check_designatino_field=get_custome_field($id, "Designation"); // Custom Field name for designation is "Designation".
     if($check_designatino_field != 0 ) {
-        $table .='<tr><td>Job Title</td><td>'.$check_designatino_field.'</td></tr>';
+        $table .='<tr><td>'.get_string('job_title', 'block_course_status_tracker').'</td><td>'.format_string($check_designatino_field).'</td></tr>';
     }
-   $table .='<tr><td>'.get_string('department', 'block_course_status_tracker').'</td><td>'.$result->department.'</td></tr>
-             <tr><td>'.get_string('joining_date', 'block_course_status_tracker').'</td><td>'.$result->date.'</td></tr>
+    $table .='<tr><td>'.get_string('department', 'block_course_status_tracker').'</td><td>'.format_string($result->department).'</td></tr>
+             <tr><td>'.get_string('joining_date', 'block_course_status_tracker').'</td><td>'.userdate($result->date, get_string('strftimedate', 'core_langconfig')).'</td></tr>
              </table>';
     return $table;
 }
@@ -140,11 +140,11 @@ function get_custome_field($userid, $text) {
     $result = $DB->get_record_sql('SELECT table2.data as fieldvalue  FROM {user_info_field} as table1  join  {user_info_data} as table2
                                    on table1.id=table2.fieldid where table2.userid=? AND table1.name=?',
                                    array($userid, $text));
-    $fieldvalue=$result->fieldvalue;
-    if(empty($fieldvalue)) {
+
+    if(empty($$result->fieldvalue)) {
         return "0";
     } else {
-        return $result->fieldvalue;
+        return format_string($result->fieldvalue);
     }
 }
 /**

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 Course Status Tracker
 
-Author: Azmat Ullah, Talha Noor
+Author: Azmat Ullah, Talha Noor, Michael Milette (www.instruxmedia.com)
 
 Plugin Installation
 
-1) Copy plugin folder in moodle blocks folder
+1) Copy plugin folder in Moodle blocks folder
 2) Login with Administrator on Moodle site
 3) Install the plugin by clicking on 'update database' now button
 Course completion settings
@@ -12,5 +12,5 @@ __________________________
 Login with admin account
 Click on advanced feature under site administrator block
 Checked 'Enable completion tracking' and click on 'Save'.
-Goto course where you want to track the course status and enable course completion tracking
+Go to course where you want to track the course status and enable course completion tracking
 Click on 'Save changes'

--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,16 @@
+Course Status Tracker
+
+Author: Azmat Ullah, Talha Noor
+
+Plugin Installation
+
+1) Copy plugin folder in moodle blocks folder
+2) Login with Administrator on Moodle site
+3) Install the plugin by clicking on 'update database' now button
+Course completion settings
+__________________________
+Login with admin account
+Click on advanced feature under site administrator block
+Checked 'Enable completion tracking' and click on 'Save'.
+Goto course where you want to track the course status and enable course completion tracking
+Click on 'Save changes'

--- a/version.php
+++ b/version.php
@@ -18,11 +18,11 @@
  * The plugin shows the number and list of enrolled courses and completed courses.
  * It also shows the number of courses which are in progress and whose completion criteria is undefined but the manger.
  * @package blocks
- * @author: Azmat Ullah, Talha Noor
+ * @author: Azmat Ullah, Talha Noor, Michael Milette (www.instruxmedia.com)
  * @date: 13th Aug, 2013
  */
 
-$plugin->version   = 2013060700;        // The current plugin version (Date: YYYYMMDDXX)
+$plugin->version   = 2013060703;        // The current plugin version (Date: YYYYMMDDXX)
 $plugin->requires  = 2010112400;        // Requires this Moodle version
 $plugin->release = '2.3';
 $plugin->maturity = MATURITY_BETA;

--- a/version.php
+++ b/version.php
@@ -1,0 +1,27 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/* Course Status Tracker Block
+ * The plugin shows the number and list of enrolled courses and completed courses.
+ * It also shows the number of courses which are in progress and whose completion criteria is undefined but the manger.
+ * @package blocks
+ * @author: Azmat Ullah, Talha Noor
+ * @date: 13th Aug, 2013
+ */
+
+$plugin->version   = 2013060700;        // The current plugin version (Date: YYYYMMDDXX)
+$plugin->requires  = 2010112400;        // Requires this Moodle version
+$plugin->release = '2.3';

--- a/version.php
+++ b/version.php
@@ -25,3 +25,4 @@
 $plugin->version   = 2013060700;        // The current plugin version (Date: YYYYMMDDXX)
 $plugin->requires  = 2010112400;        // Requires this Moodle version
 $plugin->release = '2.3';
+$plugin->maturity = MATURITY_BETA;

--- a/view.php
+++ b/view.php
@@ -34,7 +34,7 @@ $pageurl = new moodle_url('/blocks/course_status/view.php');
 echo $OUTPUT->header();
 $viewpage = required_param('viewpage', PARAM_INT);
 if($viewpage == 1) {
-    $form = new block_course_status_tracker();
+    $form = new course_status_form();
     $table=$form->display_report();
     if($table) {
         echo "<div id='prints'>";

--- a/view.php
+++ b/view.php
@@ -40,7 +40,7 @@ if($viewpage == 1) {
     $table=$form->display_report();
     if($table) {
         echo "<div id='prints'>";
-        $title = '<center><table width="80%" style="background-color:#F3F3F3;"><tr><td><center><h2>Course Completion Report</h2></center></td></tr></tr><table></center>';
+        $title = '<center><table width="80%" style="background-color:#F3F3F3;"><tr><td><center><h2>'.get_string('report_coursecompletion', 'block_course_status_tracker').'</h2></center></td></tr></tr><table></center>';
         $title.=user_details($USER->id);
         $a= html_writer::table($table);
         echo $title;
@@ -57,14 +57,14 @@ if($viewpage == 1) {
         echo "</div>";
         } else if ($viewpage == 3) {
             echo "<div id='prints'>";
-            $title = '<center><table width="80%" style="background-color:#EEE;"><tr><td><center><h2>Course Enrollment Report</h2></center></td></tr></tr><table></center>';
+           $title = '<center><table width="80%" style="background-color:#EEE;"><tr><td><center><h2>'.get_string('report_courseenrollment', 'block_course_status_tracker').'</h2></center></td></tr></tr><table></center>';
             $title.=user_details($USER->id);
             echo $title;
             echo  html_writer::table(user_enrolled_courses_report($USER->id));
             echo "</div>";
             } else if ($viewpage == 4) {
                 echo "<div id='prints'>";
-                $title = '<center><table width="100%" style="background-color:#EEE;"><tr><td><center><h2>Course Enrollment Report</h2></center></td></tr></tr><table></center>';
+                $title = '<center><table width="100%" style="background-color:#EEE;"><tr><td><center><h2>'.get_string('report_courseenrollment', 'block_course_status_tracker').'</h2></center></td></tr></tr><table></center>';
                 $title.=user_details($USER->id);
                 echo $title;
                 echo  html_writer::table(user_enrolled_courses_report($USER->id));

--- a/view.php
+++ b/view.php
@@ -18,31 +18,32 @@
  * The plugin shows the number and list of enrolled courses and completed courses.
  * It also shows the number of courses which are in progress and whose completion criteria is undefined but the manger.
  * @package blocks
- * @author: Azmat Ullah, Talha Noor
+ * @author: Azmat Ullah, Talha Noor, Michael Milette (www.instruxmedia.com)
  */
-
-// require_once('../../printemailpdf/head.php'); // Head for Print & Email.
 require_once('../../config.php');
 require_once('course_form.php');
-require_once("lib.php");
+require_once('lib.php');
+
 require_login();
+
 global $DB, $OUTPUT, $PAGE, $CFG, $USER;
 $context = context_system::instance();
 $PAGE->set_context($context);
 $PAGE->set_pagelayout('standard');
 $PAGE->set_title(get_string("pluginname", 'block_course_status_tracker'));
 $PAGE->set_heading('Course Status');
-$pageurl = new moodle_url('/blocks/course_status/view.php');
+$pageurl = new moodle_url('/blocks/course_status_tracker/view.php');
 $PAGE->navbar->ignore_active();
 $PAGE->navbar->add(get_string("pluginname", 'block_course_status_tracker'));
 echo $OUTPUT->header();
+
 $viewpage = required_param('viewpage', PARAM_INT);
 if($viewpage == 1) {
     $form = new course_status_form();
     $table=$form->display_report();
     if($table) {
         echo "<div id='prints'>";
-        $title = '<center><table width="80%" style="background-color:#F3F3F3;"><tr><td><center><h2>'.get_string('report_coursecompletion', 'block_course_status_tracker').'</h2></center></td></tr></tr><table></center>';
+        $title = '<h2>'.get_string('report_coursecompletion', 'block_course_status_tracker').'</h2>';
         $title.=user_details($USER->id);
         $a= html_writer::table($table);
         echo $title;
@@ -50,29 +51,32 @@ if($viewpage == 1) {
         echo "</div>";
     }
 } else if ($viewpage == 2) {
-        echo "<div id='prints'>";
-        $title = '<center><table width="80%" style="background-color:#F3F3F3;"><tr><td><center><h2>Course Enrollment Report</h2></center></td></tr></tr><table></center>';
-        $title.=user_details($USER->id);
-        echo $title;
-        $a= html_writer::table(user_enrolled_courses_report($USER->id));
-        echo $a;
-        echo "</div>";
-        } else if ($viewpage == 3) {
-            echo "<div id='prints'>";
-           $title = '<center><table width="80%" style="background-color:#EEE;"><tr><td><center><h2>'.get_string('report_courseenrollment', 'block_course_status_tracker').'</h2></center></td></tr></tr><table></center>';
-            $title.=user_details($USER->id);
-            echo $title;
-            echo  html_writer::table(user_enrolled_courses_report($USER->id));
-            echo "</div>";
-            } else if ($viewpage == 4) {
-                echo "<div id='prints'>";
-                $title = '<center><table width="100%" style="background-color:#EEE;"><tr><td><center><h2>'.get_string('report_courseenrollment', 'block_course_status_tracker').'</h2></center></td></tr></tr><table></center>';
-                $title.=user_details($USER->id);
-                echo $title;
-                echo  html_writer::table(user_enrolled_courses_report($USER->id));
-                echo "</div>";
-                } else header($CFG->wwwroot);
+    echo "<div id='prints'>";
+    $title = '<h2>'.get_string('report_courseenrollment', 'block_course_status_tracker').'</h2>';
+    $title.=user_details($USER->id);
+    echo $title;
+    $a= html_writer::table(user_enrolled_courses_report($USER->id));
+    echo $a;
+    echo "</div>";
+} else if ($viewpage == 3) {
+    echo "<div id='prints'>";
+    $title = '<h2>'.get_string('report_courseenrollment', 'block_course_status_tracker').'</h2>';
+    $title.=user_details($USER->id);
+    echo $title;
+    echo  html_writer::table(user_enrolled_courses_report($USER->id));
+    echo "</div>";
+} else if ($viewpage == 4) {
+    echo "<div id='prints'>";
+    $title = '<h2>'.get_string('report_courseenrollment', 'block_course_status_tracker').'</h2>';
+    $title.=user_details($USER->id);
+    echo $title;
+    echo  html_writer::table(user_enrolled_courses_report($USER->id));
+    echo "</div>";
+} else {
+    header($CFG->wwwroot);
+}
 
-$reporthtml=$a;
+// $reporthtml=$a;
 // require_once('../../printemailpdf/displaybutton.php');
+
 echo $OUTPUT->footer();

--- a/view.php
+++ b/view.php
@@ -27,6 +27,8 @@ require_once('course_form.php');
 require_once("lib.php");
 require_login();
 global $DB, $OUTPUT, $PAGE, $CFG, $USER;
+$context = context_system::instance();
+$PAGE->set_context($context);
 $PAGE->set_pagelayout('standard');
 $PAGE->set_title(get_string("pluginname", 'block_course_status_tracker'));
 $PAGE->set_heading('Course Status');

--- a/view.php
+++ b/view.php
@@ -1,0 +1,75 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/* Course Status Tracker Block
+ * The plugin shows the number and list of enrolled courses and completed courses.
+ * It also shows the number of courses which are in progress and whose completion criteria is undefined but the manger.
+ * @package blocks
+ * @author: Azmat Ullah, Talha Noor
+ * @date: 2013
+ */
+
+// require_once('../../printemailpdf/head.php'); // Head for Print & Email.
+require_once('../../config.php');
+require_once('course_form.php');
+require_once("lib.php");
+require_login();
+global $DB, $OUTPUT, $PAGE, $CFG, $USER;
+$PAGE->set_pagelayout('standard');
+$PAGE->set_title(get_string("pluginname", 'block_course_status_tracker'));
+$PAGE->set_heading('Course Status');
+$pageurl = new moodle_url('/blocks/course_status/view.php');
+echo $OUTPUT->header();
+$viewpage = required_param('viewpage', PARAM_INT);
+if($viewpage == 1) {
+    $form = new block_course_status_tracker();
+    $table=$form->display_report();
+    if($table) {
+        echo "<div id='prints'>";
+        $title = '<center><table width="80%" style="background-color:#F3F3F3;"><tr><td><center><h2>Course Completion Report</h2></center></td></tr></tr><table></center>';
+        $title.=user_details($USER->id);
+        $a= html_writer::table($table);
+        echo $title;
+        echo $a;
+        echo "</div>";
+    }
+} else if ($viewpage == 2) {
+        echo "<div id='prints'>";
+        $title = '<center><table width="80%" style="background-color:#F3F3F3;"><tr><td><center><h2>Course Enrollment Report</h2></center></td></tr></tr><table></center>';
+        $title.=user_details($USER->id);
+        echo $title;
+        $a= html_writer::table(user_enrolled_courses_report($USER->id));
+        echo $a;
+        echo "</div>";
+        } else if ($viewpage == 3) {
+            echo "<div id='prints'>";
+            $title = '<center><table width="80%" style="background-color:#EEE;"><tr><td><center><h2>Course Enrollment Report</h2></center></td></tr></tr><table></center>';
+            $title.=user_details($USER->id);
+            echo $title;
+            echo  html_writer::table(user_enrolled_courses_report($USER->id));
+            echo "</div>";
+            } else if ($viewpage == 4) {
+                echo "<div id='prints'>";
+                $title = '<center><table width="100%" style="background-color:#EEE;"><tr><td><center><h2>Course Enrollment Report</h2></center></td></tr></tr><table></center>';
+                $title.=user_details($USER->id);
+                echo $title;
+                echo  html_writer::table(user_enrolled_courses_report($USER->id));
+                echo "</div>";
+                } else header($CFG->wwwroot);
+
+$reporthtml=$a;
+// require_once('../../printemailpdf/displaybutton.php');
+echo $OUTPUT->footer();

--- a/view.php
+++ b/view.php
@@ -31,6 +31,8 @@ $PAGE->set_pagelayout('standard');
 $PAGE->set_title(get_string("pluginname", 'block_course_status_tracker'));
 $PAGE->set_heading('Course Status');
 $pageurl = new moodle_url('/blocks/course_status/view.php');
+$PAGE->navbar->ignore_active();
+$PAGE->navbar->add(get_string("pluginname", 'block_course_status_tracker'));
 echo $OUTPUT->header();
 $viewpage = required_param('viewpage', PARAM_INT);
 if($viewpage == 1) {

--- a/view.php
+++ b/view.php
@@ -19,7 +19,6 @@
  * It also shows the number of courses which are in progress and whose completion criteria is undefined but the manger.
  * @package blocks
  * @author: Azmat Ullah, Talha Noor
- * @date: 2013
  */
 
 // require_once('../../printemailpdf/head.php'); // Head for Print & Email.


### PR DESCRIPTION
...rty of non-object

This patch addresses the following issue:
- Applies Moodle output filtering to data coming from database so that
  it gets formatted correctly if using the Multi-lingual or Multi-language
  plugins.
- Applies date formatting using the userdate() function so that dates
  now appear in the user interface language.
- Fixes the following notice which appears in the Course Enrolment Report
  (viewpage 2):
  Notice: Trying to get property of non-object in /www/phacmoodle/moodle/phac-moodle/blocks/course_status_tracker/lib.php on line 145
- Fixes the following notice which appear in all viewpages except 1 and 2:
  Notice: Undefined variable: a in /www/phacmoodle/moodle/phac-moodle/blocks/course_status_tracker/view.php on line 75
- Removed CENTER tags that were formatting the header table. CENTER is not
  supported in HTML5 standard (was deprecated before that already)
  (WCAG 2.0)
- Removed TABLE and related tags that were formatting the H2 header.
  Tables should not be used for the purpose of formatting content on a
  page. This also allows themes to apply their own colour schemes using
  styles for a more consistent overall site presentation (WCAG 2.0).
- Fixed some minor typos.
- Fixed some source code formatting issues such as:
  - inconsistent indentations
  - tabs instead of space
  - trailing spaces
- Include the changes published on moodle.org in version 2013060701 and
  2013060702 (current version on GitHub - 2013060700 - is outdated)

Please contact me if you have any questions or concerns regading these
modifications.

Signed-off-by: Michael Milette michael.milette@instruxmedia.com
